### PR TITLE
fix: remove userId column from Article table

### DIFF
--- a/prisma/migrations/20260213083357_remove_user_id/migration.sql
+++ b/prisma/migrations/20260213083357_remove_user_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `userId` on the `Article` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Article" DROP COLUMN "userId";


### PR DESCRIPTION
Only needed to create and apply a new migration.